### PR TITLE
Check for strictness flag from 0 to None. Fixes #9

### DIFF
--- a/acronym/acronym.py
+++ b/acronym/acronym.py
@@ -153,7 +153,7 @@ def main():
                         help='How strictly should the words be related to real English?')
     args = parser.parse_args()
 
-    if args.strict == 0:
+    if args.strict == None:
         corpus = nltk.corpus.words
     elif args.strict == 1:
         corpus = nltk.corpus.brown


### PR DESCRIPTION
By default, the default value of a count flag is None, and not 0 as expected. It was pretty much impossible to use this specific corpus.